### PR TITLE
Allow the setting of the default Trello list card position and allow ability to use the short URL returned by Trello

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@ This plugin provides seamless integration between Logseq and Trello, allowing yo
 2. Set the default position for newly created Trello cards
   - Valid values are `top`, `bottom` (default) or an absolute numeric position
 
-### 5. Available Commands
+### 5. Use short or long URL
+1. Go to Plugin Settings > logseq-trello-plugin
+2. Setup to use either the short or long URL when adding the URL link to the block/page after creating a Trello card
+
+### 6. Available Commands
 - `/Send Block to Trello`: Creates a new card from your current block
 - `/Send Page to Trello`: Creates a new card from your current page (can trigger anywhere within the page)
 - `/Trello Get Lists`: Shows all your Trello boards and lists
 - `/Trello Pull Cards`: Imports all cards from your default list
 
-### 6. Working with Cards
+### . Working with Cards
 1. **Creating Cards**:
    - Select a block or page you want to send to Trello
    - Use `/Send Block to Trello` or `/Send Page to Trello`

--- a/README.md
+++ b/README.md
@@ -39,13 +39,18 @@ This plugin provides seamless integration between Logseq and Trello, allowing yo
 2. Copy your preferred List ID
 3. Paste it in plugin settings under "Default List ID"
 
-### 4. Available Commands
+### 4. Set Default Card Position
+1. Go to Plugin Settings > logseq-trello-plugin
+2. Set the default position for newly created Trello cards
+  - Valid values are `top`, `bottom` (default) or an absolute numeric position
+
+### 5. Available Commands
 - `/Send Block to Trello`: Creates a new card from your current block
 - `/Send Page to Trello`: Creates a new card from your current page (can trigger anywhere within the page)
 - `/Trello Get Lists`: Shows all your Trello boards and lists
 - `/Trello Pull Cards`: Imports all cards from your default list
 
-### 5. Working with Cards
+### 6. Working with Cards
 1. **Creating Cards**:
    - Select a block or page you want to send to Trello
    - Use `/Send Block to Trello` or `/Send Page to Trello`

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This plugin provides seamless integration between Logseq and Trello, allowing yo
 - `/Trello Get Lists`: Shows all your Trello boards and lists
 - `/Trello Pull Cards`: Imports all cards from your default list
 
-### . Working with Cards
+### 7. Working with Cards
 1. **Creating Cards**:
    - Select a block or page you want to send to Trello
    - Use `/Send Block to Trello` or `/Send Page to Trello`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This plugin provides seamless integration between Logseq and Trello, allowing yo
   * Updates existing cards instead of creating new ones
   * Maintains consistent links between platforms
 - Import content in clean, block-based format for easy editing
+- Allows the ability to convert a Logseq block into a task after the Trello card has been created
+  * Handles both the TODO/DOING and LATER/NOW constructs
+  * Does not convert a page to a task when creating a Trello card from a Logseq page
 
 ## Getting Started
 
@@ -48,13 +51,18 @@ This plugin provides seamless integration between Logseq and Trello, allowing yo
 1. Go to Plugin Settings > logseq-trello-plugin
 2. Setup to use either the short or long URL when adding the URL link to the block/page after creating a Trello card
 
-### 6. Available Commands
+### 6. Convert block to task
+1. Go to Plugin Settings > logseq-trello-plugin
+2. Set to convert the block to a task after creating a Trello card from a block
+  - Note: the action of creating a Trello card from a page does **not** convert the page to a task
+
+### 7. Available Commands
 - `/Send Block to Trello`: Creates a new card from your current block
 - `/Send Page to Trello`: Creates a new card from your current page (can trigger anywhere within the page)
 - `/Trello Get Lists`: Shows all your Trello boards and lists
 - `/Trello Pull Cards`: Imports all cards from your default list
 
-### 7. Working with Cards
+### 8. Working with Cards
 1. **Creating Cards**:
    - Select a block or page you want to send to Trello
    - Use `/Send Block to Trello` or `/Send Page to Trello`

--- a/index.js
+++ b/index.js
@@ -27,6 +27,13 @@ const settings = [
     title: "Default Card Position",
     description: "The default position in Trello list for new cards.  Specify either top, bottom or an absolute numeric position",
     default: "bottom" // defaulting to bottom doesn't change existing behaviour
+  },
+  {
+    key: "shortUrl",
+    type: "boolean",
+    title: "Use short or long Trello card URL",
+    description: "Use the short URL in block/page content after creating a Trello card",
+    default: false // defaulting to false doesn't change existing behaviour
   }
 ];
 
@@ -327,11 +334,16 @@ function main() {
     try {
       const card = await createTrelloCard(token, listId, block.content, cardPosition);
       logseq.App.showMsg('Trello card created successfully!');
-      
+      let url = card.url; // default to long
+
+      if(logseq.settings?.shortUrl) {
+        url = card.shortUrl;
+      }
+
       // Add the card URL as a property to the block
       await logseq.Editor.updateBlock(
         block.uuid,
-        `${block.content}\ntrello-card:: ${card.url}`
+        `${block.content}\ntrello-card:: ${url}`
       );
 
     } catch (error) {
@@ -374,12 +386,17 @@ function main() {
       // Create card with page title and content
       const card = await createTrelloCard(token, listId, page.name, cardPosition, description);
       logseq.App.showMsg('Trello card created from page successfully!');
-      
+      let url = card.url; // default to long
+
+      if(logseq.settings?.shortUrl) {
+        url = card.shortUrl;
+      }
+
       // Add the card URL as a page property
       await logseq.Editor.upsertBlockProperty(
         page.uuid,
         'trello-card',
-        card.url
+        url
       );
 
     } catch (error) {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,13 @@ const settings = [
     title: "Default List ID",
     description: "Use /Trello Get Lists to find your list ID, then paste it here",
     default: ""
+  },
+  {
+    key: "defaultCardPos",
+    type: "string",
+    title: "Default Card Position",
+    description: "The default position in Trello list for new cards.  Specify either top, bottom or an absolute numeric position",
+    default: "bottom" // defaulting to bottom doesn't change existing behaviour
   }
 ];
 
@@ -71,7 +78,7 @@ async function checkExistingCard(token, listId, name) {
   return cards.find(card => card.name === name);
 }
 
-async function createTrelloCard(token, listId, name, desc = '') {
+async function createTrelloCard(token, listId, name, cardPosition, desc = '') {
   // First check if card already exists
   const existingCard = await checkExistingCard(token, listId, name);
   if (existingCard) {
@@ -108,7 +115,8 @@ async function createTrelloCard(token, listId, name, desc = '') {
       body: JSON.stringify({
         name,
         idList: listId,
-        desc
+        desc: desc,
+        pos: cardPosition
       })
     }
   );
@@ -304,6 +312,7 @@ function main() {
     // Get settings
     const token = logseq.settings?.trelloToken;
     const listId = logseq.settings?.defaultListId;
+    const cardPosition = logseq.settings?.defaultCardPos;
 
     if (!token) {
       logseq.App.showMsg('Please configure your Trello token in plugin settings!', 'warning');
@@ -316,7 +325,7 @@ function main() {
     }
 
     try {
-      const card = await createTrelloCard(token, listId, block.content);
+      const card = await createTrelloCard(token, listId, block.content, cardPosition);
       logseq.App.showMsg('Trello card created successfully!');
       
       // Add the card URL as a property to the block
@@ -336,6 +345,7 @@ function main() {
     // Get settings
     const token = logseq.settings?.trelloToken;
     const listId = logseq.settings?.defaultListId;
+    const cardPosition = logseq.settings?.defaultCardPos;
 
     if (!token) {
       logseq.App.showMsg('Please configure your Trello token in plugin settings!', 'warning');
@@ -362,7 +372,7 @@ function main() {
         .join('\n');
 
       // Create card with page title and content
-      const card = await createTrelloCard(token, listId, page.name, description);
+      const card = await createTrelloCard(token, listId, page.name, cardPosition, description);
       logseq.App.showMsg('Trello card created from page successfully!');
       
       // Add the card URL as a page property

--- a/index.js
+++ b/index.js
@@ -34,6 +34,13 @@ const settings = [
     title: "Use short or long Trello card URL",
     description: "Use the short URL in block/page content after creating a Trello card",
     default: false // defaulting to false doesn't change existing behaviour
+  },
+  {
+    key: "convertToTask",
+    type: "boolean",
+    title: "Convert block to a task after creating Trello card",
+    description: "After creating the Trello card from a block, convert the block to a task",
+    default: false // defaulting to false doesn't change existing behaviour
   }
 ];
 
@@ -334,16 +341,28 @@ function main() {
     try {
       const card = await createTrelloCard(token, listId, block.content, cardPosition);
       logseq.App.showMsg('Trello card created successfully!');
-      let url = card.url; // default to long
 
+      let url = card.url; // default to long
       if(logseq.settings?.shortUrl) {
         url = card.shortUrl;
+      }
+
+      // Convert block to a task if convertToTask == True
+      //   Ensure that we handle both TODO/DOING and LATER/NOW constructs using the preferredTodo user config value
+      const preferredTodo = (await logseq.App.getUserConfigs()).preferredTodo; 
+      let task = ""; // default to not being a task
+
+      if(logseq.settings?.convertToTask) {
+        if(! block.content.startsWith(preferredTodo)) {
+          // Not already a task so add prefix
+          task = preferredTodo.concat(' ');
+        }
       }
 
       // Add the card URL as a property to the block
       await logseq.Editor.updateBlock(
         block.uuid,
-        `${block.content}\ntrello-card:: ${url}`
+        `${task}${block.content}\ntrello-card:: ${url}`
       );
 
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-trello-plugin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "jarodise",
   "main": "index.html",
   "description": "📋 Trello integration for LogSeq",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-trello-plugin",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "jarodise",
   "main": "index.html",
   "description": "📋 Trello integration for LogSeq",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-trello-plugin",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "jarodise",
   "main": "index.html",
   "description": "📋 Trello integration for LogSeq",


### PR DESCRIPTION
- When creating a new card in an existing Trello list, allow setting of the default card position.
- Default is to create the card at the bottom of the list.
- This new setting defaultCardPos accepts values of **bottom**, **top** or an absolute numeric card position.
- Allow the ability to use the short URL returned by the Trello API. This short URL does not take as much line space, and likely will not wrap o to the next line in the block/page
- Add functionality to optionally convert the Logseq block into a TODO/LATER task after creating the Trello card
